### PR TITLE
better handle multiple paths to parse

### DIFF
--- a/internal/distributions/metadata.go
+++ b/internal/distributions/metadata.go
@@ -63,7 +63,7 @@ func NewDistributionMetadata(filename string) (Distribution, string, string, err
 		// "bdist_egg":     BDist,
 	}
 	if err != nil {
-		return nil, "", "", fmt.Errorf("invalid distribution file: %s, err: %v", filepath.Base(filename), err)
+		return nil, "", "", fmt.Errorf("invalid distribution file: %s: %v", filepath.Base(filename), err)
 	}
 
 	// If this encounters a metadata version it doesn't support, it may give us

--- a/internal/distributions/sdist.go
+++ b/internal/distributions/sdist.go
@@ -3,11 +3,12 @@ package distributions
 import (
 	"bytes"
 	"fmt"
-	"github.com/rstudio/python-distribution-parser/internal/archiver"
 	"log"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/rstudio/python-distribution-parser/internal/archiver"
 )
 
 type SDist struct {

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -1,37 +1,13 @@
 package packages
 
 import (
-	"errors"
-	"github.com/rstudio/python-distribution-parser/internal/distributions"
-	"github.com/samber/lo"
-	"io"
-	"log"
-	"os"
 	"path/filepath"
+
+	"github.com/rstudio/python-distribution-parser/internal/distributions"
+	"github.com/rstudio/python-distribution-parser/types"
 )
 
-type PackageFile struct {
-	Filename           string                      `json:"file_name"`
-	Comment            string                      `json:"comment"`
-	BaseFilename       string                      `json:"base_filename"`
-	Metadata           *distributions.Distribution `json:"metadata"`
-	PythonVersion      string                      `json:"pyversion"`
-	FileType           string                      `json:"filetype"`
-	SafeName           string                      `json:"safe_name"`
-	SignedFilename     string                      `json:"signed_filename"`
-	SignedBaseFilename string                      `json:"signed_base_filename"`
-	GPGSignature       *Signature                  `json:"gpg_signature"`
-	MD5Digest          string                      `json:"md5_digest"`
-	SHA2Digest         string                      `json:"sha256_digest"`
-	Blake2_256Digest   string                      `json:"blake2_256_digest"`
-}
-
-type Signature struct {
-	Filename string `json:"signed_filename"`
-	Bytes    []byte `json:"signed_bytes"`
-}
-
-func NewPackageFile(filename string) (*PackageFile, error) {
+func NewPackageFile(filename string) (*types.PackageFile, error) {
 	metadata, pythonVersion, fileType, err := distributions.NewDistributionMetadata(filename)
 	if err != nil {
 		return nil, err
@@ -53,7 +29,7 @@ func NewPackageFile(filename string) (*PackageFile, error) {
 	}
 	hexdigest := hashManager.HexDigest()
 
-	return &PackageFile{
+	return &types.PackageFile{
 		Filename:           filename,
 		Comment:            "", // Adding a comment isn't currently possible
 		BaseFilename:       baseFilename,
@@ -67,88 +43,4 @@ func NewPackageFile(filename string) (*PackageFile, error) {
 		SHA2Digest:         hexdigest.sha2,
 		Blake2_256Digest:   hexdigest.blake2,
 	}, nil
-}
-
-func (pf *PackageFile) MetadataMap() map[string][]string {
-	pkgMap := distributions.StructToMap(pf)
-	metadata := *pf.Metadata
-	metadataMap := metadata.MetadataMap()
-	result := make(map[string][]string, len(pkgMap)+len(metadataMap))
-	for pk, pv := range pkgMap {
-		result[pk] = pv
-	}
-	for mk, mv := range metadataMap {
-		result[mk] = mv
-	}
-
-	result["name"] = result["safe_name"]
-	// This makes the request look more like Twine
-	result["protocol_version"] = []string{"1"}
-	result[":action"] = []string{"file_upload"}
-
-	ignoredKeys := []string{
-		"base_filename",
-		"file_name",
-		"safe_name",
-		"signed_base_filename",
-		"signed_filename",
-		"metadata",
-	}
-
-	for _, key := range ignoredKeys {
-		delete(result, key)
-	}
-
-	allowedBlankValues := []string{
-		"author",
-		"author_email",
-		"comment",
-		"download_url",
-		"home_page",
-		"keywords",
-		"license",
-		"maintainer",
-		"pyversion",
-		"description_content_type",
-		"maintainer_email",
-		"requires_python",
-	}
-
-	// remove any keys that are an empty value, unless twine expects them
-	result = lo.OmitBy(result, func(key string, value []string) bool {
-		if lo.Contains(allowedBlankValues, key) {
-			return false
-		}
-		return value == nil || len(value) == 1 && (value[0] == "" || value[0] == "<nil>")
-	})
-
-	return result
-}
-
-func (pf *PackageFile) AddGPGSignature(signatureFilepath string, signatureFilename string) error {
-	if pf.GPGSignature != nil {
-		return errors.New("GPG Signature can only be added once")
-	}
-
-	gpg, err := os.Open(signatureFilepath)
-	if err != nil {
-		return err
-	}
-	defer func(gpg *os.File) {
-		err := gpg.Close()
-		if err != nil {
-			log.Printf("error closing file: %v", err)
-		}
-	}(gpg)
-
-	bytes, err := io.ReadAll(gpg)
-	if err != nil {
-		return err
-	}
-
-	pf.GPGSignature = &Signature{
-		Filename: signatureFilename,
-		Bytes:    bytes,
-	}
-	return nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+
+	"github.com/rstudio/python-distribution-parser/internal/distributions"
+	"github.com/samber/lo"
+)
+
+type PackageFile struct {
+	Filename           string                      `json:"file_name"`
+	Comment            string                      `json:"comment"`
+	BaseFilename       string                      `json:"base_filename"`
+	Metadata           *distributions.Distribution `json:"metadata"`
+	PythonVersion      string                      `json:"pyversion"`
+	FileType           string                      `json:"filetype"`
+	SafeName           string                      `json:"safe_name"`
+	SignedFilename     string                      `json:"signed_filename"`
+	SignedBaseFilename string                      `json:"signed_base_filename"`
+	GPGSignature       *Signature                  `json:"gpg_signature"`
+	MD5Digest          string                      `json:"md5_digest"`
+	SHA2Digest         string                      `json:"sha256_digest"`
+	Blake2_256Digest   string                      `json:"blake2_256_digest"`
+}
+
+type Signature struct {
+	Filename string `json:"signed_filename"`
+	Bytes    []byte `json:"signed_bytes"`
+}
+
+func (pf *PackageFile) MetadataMap() map[string][]string {
+	pkgMap := distributions.StructToMap(pf)
+	metadata := *pf.Metadata
+	metadataMap := metadata.MetadataMap()
+	result := make(map[string][]string, len(pkgMap)+len(metadataMap))
+	for pk, pv := range pkgMap {
+		result[pk] = pv
+	}
+	for mk, mv := range metadataMap {
+		result[mk] = mv
+	}
+
+	result["name"] = result["safe_name"]
+	// This makes the request look more like Twine
+	result["protocol_version"] = []string{"1"}
+	result[":action"] = []string{"file_upload"}
+
+	ignoredKeys := []string{
+		"base_filename",
+		"file_name",
+		"safe_name",
+		"signed_base_filename",
+		"signed_filename",
+		"metadata",
+	}
+
+	for _, key := range ignoredKeys {
+		delete(result, key)
+	}
+
+	allowedBlankValues := []string{
+		"author",
+		"author_email",
+		"comment",
+		"download_url",
+		"home_page",
+		"keywords",
+		"license",
+		"maintainer",
+		"pyversion",
+		"description_content_type",
+		"maintainer_email",
+		"requires_python",
+	}
+
+	// remove any keys that are an empty value, unless twine expects them
+	result = lo.OmitBy(result, func(key string, value []string) bool {
+		if lo.Contains(allowedBlankValues, key) {
+			return false
+		}
+		return value == nil || len(value) == 1 && (value[0] == "" || value[0] == "<nil>")
+	})
+
+	return result
+}
+
+func (pf *PackageFile) AddGPGSignature(signatureFilepath string, signatureFilename string) error {
+	if pf.GPGSignature != nil {
+		return errors.New("GPG Signature can only be added once")
+	}
+
+	gpg, err := os.Open(signatureFilepath)
+	if err != nil {
+		return err
+	}
+	defer func(gpg *os.File) {
+		err := gpg.Close()
+		if err != nil {
+			log.Printf("error closing file: %v", err)
+		}
+	}(gpg)
+
+	bytes, err := io.ReadAll(gpg)
+	if err != nil {
+		return err
+	}
+
+	pf.GPGSignature = &Signature{
+		Filename: signatureFilename,
+		Bytes:    bytes,
+	}
+	return nil
+}


### PR DESCRIPTION
### Description

This changes Parse(string) to Parse(...string) so that it can handle both a single path, as well as a slice of paths.

This commit also:
- Makes PackageFile exposed externally so that it is a type that can be passed around.
- Updates the error message when a package can't be parsed to make it more clear that it might not be a valid Python package.
- Handles case where it was double closing the tarReader for source distributions: `error closing reader: close /rstudio-pm/appdirs/dist/appdirs-1.4.4.tar.gz: file already closed`