### PR TITLE
tests: don't save version in snapshot

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 1 * *" # run on the first of each month
 
 jobs:
   test:

--- a/.snapshots/TestParse-appdirs_signed_tarball
+++ b/.snapshots/TestParse-appdirs_signed_tarball
@@ -85,7 +85,7 @@
       (string) (len=97) "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "1.4.4"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-appdirs_signed_wheel
+++ b/.snapshots/TestParse-appdirs_signed_wheel
@@ -85,7 +85,7 @@
       (string) (len=97) "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "1.4.4"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-appdirs_unsigned_tarball
+++ b/.snapshots/TestParse-appdirs_unsigned_tarball
@@ -85,7 +85,7 @@
       (string) (len=97) "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "1.4.4"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-appdirs_unsigned_wheel
+++ b/.snapshots/TestParse-appdirs_unsigned_wheel
@@ -85,7 +85,7 @@
       (string) (len=97) "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "1.4.4"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-cachetools_signed_tarball
+++ b/.snapshots/TestParse-cachetools_signed_tarball
@@ -83,7 +83,7 @@
       (string) (len=47) "Extensible memoizing collections and decorators"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.3.2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-cachetools_signed_wheel
+++ b/.snapshots/TestParse-cachetools_signed_wheel
@@ -83,7 +83,7 @@
       (string) (len=47) "Extensible memoizing collections and decorators"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.3.2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-cachetools_unsigned_tarball
+++ b/.snapshots/TestParse-cachetools_unsigned_tarball
@@ -83,7 +83,7 @@
       (string) (len=47) "Extensible memoizing collections and decorators"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.3.2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-cachetools_unsigned_wheel
+++ b/.snapshots/TestParse-cachetools_unsigned_wheel
@@ -83,7 +83,7 @@
       (string) (len=47) "Extensible memoizing collections and decorators"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.3.2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-chardet_signed_tarball
+++ b/.snapshots/TestParse-chardet_signed_tarball
@@ -89,7 +89,7 @@
       (string) (len=40) "Universal encoding detector for Python 3"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "5.3.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-chardet_signed_wheel
+++ b/.snapshots/TestParse-chardet_signed_wheel
@@ -89,7 +89,7 @@
       (string) (len=40) "Universal encoding detector for Python 3"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "5.3.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-chardet_unsigned_tarball
+++ b/.snapshots/TestParse-chardet_unsigned_tarball
@@ -89,7 +89,7 @@
       (string) (len=40) "Universal encoding detector for Python 3"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "5.3.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-chardet_unsigned_wheel
+++ b/.snapshots/TestParse-chardet_unsigned_wheel
@@ -89,7 +89,7 @@
       (string) (len=40) "Universal encoding detector for Python 3"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "5.3.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-click_signed_tarball
+++ b/.snapshots/TestParse-click_signed_tarball
@@ -85,7 +85,7 @@
       (string) (len=41) "Composable command line interface toolkit"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "8.2.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-click_signed_wheel
+++ b/.snapshots/TestParse-click_signed_wheel
@@ -85,7 +85,7 @@
       (string) (len=41) "Composable command line interface toolkit"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "8.2.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-click_unsigned_tarball
+++ b/.snapshots/TestParse-click_unsigned_tarball
@@ -85,7 +85,7 @@
       (string) (len=41) "Composable command line interface toolkit"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "8.2.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-click_unsigned_wheel
+++ b/.snapshots/TestParse-click_unsigned_wheel
@@ -85,7 +85,7 @@
       (string) (len=41) "Composable command line interface toolkit"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "8.2.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-configparser_signed_tarball
+++ b/.snapshots/TestParse-configparser_signed_tarball
@@ -98,7 +98,7 @@
       (string) (len=53) "Updated configparser from stdlib for earlier Pythons."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.0.1.dev11+g8411aec"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-configparser_signed_wheel
+++ b/.snapshots/TestParse-configparser_signed_wheel
@@ -98,7 +98,7 @@
       (string) (len=53) "Updated configparser from stdlib for earlier Pythons."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.0.1.dev11+g8411aec"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-configparser_unsigned_tarball
+++ b/.snapshots/TestParse-configparser_unsigned_tarball
@@ -98,7 +98,7 @@
       (string) (len=53) "Updated configparser from stdlib for earlier Pythons."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.0.1.dev11+g8411aec"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-configparser_unsigned_wheel
+++ b/.snapshots/TestParse-configparser_unsigned_wheel
@@ -98,7 +98,7 @@
       (string) (len=53) "Updated configparser from stdlib for earlier Pythons."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.0.1.dev11+g8411aec"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-coveragepy_signed_tarball
+++ b/.snapshots/TestParse-coveragepy_signed_tarball
@@ -98,7 +98,7 @@
       (string) (len=36) "Code coverage measurement for Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=12) "7.3.3a0.dev1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-coveragepy_signed_wheel
+++ b/.snapshots/TestParse-coveragepy_signed_wheel
@@ -98,7 +98,7 @@
       (string) (len=36) "Code coverage measurement for Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=12) "7.3.3a0.dev1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-coveragepy_unsigned_tarball
+++ b/.snapshots/TestParse-coveragepy_unsigned_tarball
@@ -98,7 +98,7 @@
       (string) (len=36) "Code coverage measurement for Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=12) "7.3.3a0.dev1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-coveragepy_unsigned_wheel
+++ b/.snapshots/TestParse-coveragepy_unsigned_wheel
@@ -98,7 +98,7 @@
       (string) (len=36) "Code coverage measurement for Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=12) "7.3.3a0.dev1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-decorator_signed_tarball
+++ b/.snapshots/TestParse-decorator_signed_tarball
@@ -87,7 +87,7 @@
       (string) (len=21) "Decorators for Humans"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.1.1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-decorator_signed_wheel
+++ b/.snapshots/TestParse-decorator_signed_wheel
@@ -87,7 +87,7 @@
       (string) (len=21) "Decorators for Humans"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.1.1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-decorator_unsigned_tarball
+++ b/.snapshots/TestParse-decorator_unsigned_tarball
@@ -87,7 +87,7 @@
       (string) (len=21) "Decorators for Humans"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.1.1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-decorator_unsigned_wheel
+++ b/.snapshots/TestParse-decorator_unsigned_wheel
@@ -87,7 +87,7 @@
       (string) (len=21) "Decorators for Humans"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=5) "5.1.1"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-defusedxml_signed_tarball
+++ b/.snapshots/TestParse-defusedxml_signed_tarball
@@ -86,7 +86,7 @@
       (string) (len=45) "XML bomb protection for Python stdlib modules"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=8) "0.8.0rc2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-defusedxml_signed_wheel
+++ b/.snapshots/TestParse-defusedxml_signed_wheel
@@ -86,7 +86,7 @@
       (string) (len=45) "XML bomb protection for Python stdlib modules"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=8) "0.8.0rc2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-defusedxml_unsigned_tarball
+++ b/.snapshots/TestParse-defusedxml_unsigned_tarball
@@ -86,7 +86,7 @@
       (string) (len=45) "XML bomb protection for Python stdlib modules"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=8) "0.8.0rc2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-defusedxml_unsigned_wheel
+++ b/.snapshots/TestParse-defusedxml_unsigned_wheel
@@ -86,7 +86,7 @@
       (string) (len=45) "XML bomb protection for Python stdlib modules"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=8) "0.8.0rc2"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-importlib_metadata_signed_tarball
+++ b/.snapshots/TestParse-importlib_metadata_signed_tarball
@@ -103,7 +103,7 @@
       (string) (len=34) "Read metadata from Python packages"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.8.1.dev17+g353c3df"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-importlib_metadata_signed_wheel
+++ b/.snapshots/TestParse-importlib_metadata_signed_wheel
@@ -103,7 +103,7 @@
       (string) (len=34) "Read metadata from Python packages"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.8.1.dev17+g353c3df"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-importlib_metadata_unsigned_tarball
+++ b/.snapshots/TestParse-importlib_metadata_unsigned_tarball
@@ -103,7 +103,7 @@
       (string) (len=34) "Read metadata from Python packages"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.8.1.dev17+g353c3df"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-importlib_metadata_unsigned_wheel
+++ b/.snapshots/TestParse-importlib_metadata_unsigned_wheel
@@ -103,7 +103,7 @@
       (string) (len=34) "Read metadata from Python packages"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=20) "6.8.1.dev17+g353c3df"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-matplotlib_signed_tarball
+++ b/.snapshots/TestParse-matplotlib_signed_tarball
@@ -110,7 +110,7 @@
       (string) (len=23) "Python plotting package"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "3.9.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-matplotlib_signed_wheel
+++ b/.snapshots/TestParse-matplotlib_signed_wheel
@@ -110,7 +110,7 @@
       (string) (len=23) "Python plotting package"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "3.9.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-matplotlib_unsigned_tarball
+++ b/.snapshots/TestParse-matplotlib_unsigned_tarball
@@ -110,7 +110,7 @@
       (string) (len=23) "Python plotting package"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "3.9.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-matplotlib_unsigned_wheel
+++ b/.snapshots/TestParse-matplotlib_unsigned_wheel
@@ -110,7 +110,7 @@
       (string) (len=23) "Python plotting package"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=10) "3.9.0.dev0"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-pytest_signed_tarball
+++ b/.snapshots/TestParse-pytest_signed_tarball
@@ -118,7 +118,7 @@
       (string) (len=43) "pytest: simple powerful testing with Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=23) "8.0.0.dev305+g8fb7e8b31"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-pytest_signed_wheel
+++ b/.snapshots/TestParse-pytest_signed_wheel
@@ -118,7 +118,7 @@
       (string) (len=43) "pytest: simple powerful testing with Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=23) "8.0.0.dev305+g8fb7e8b31"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-pytest_unsigned_tarball
+++ b/.snapshots/TestParse-pytest_unsigned_tarball
@@ -118,7 +118,7 @@
       (string) (len=43) "pytest: simple powerful testing with Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=23) "8.0.0.dev305+g8fb7e8b31"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-pytest_unsigned_wheel
+++ b/.snapshots/TestParse-pytest_unsigned_wheel
@@ -118,7 +118,7 @@
       (string) (len=43) "pytest: simple powerful testing with Python"
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=23) "8.0.0.dev305+g8fb7e8b31"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-python-certifi_signed_tarball
+++ b/.snapshots/TestParse-python-certifi_signed_tarball
@@ -85,7 +85,7 @@
       (string) (len=49) "Python package for providing Mozilla's CA Bundle."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=9) "2023.7.22"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-python-certifi_signed_wheel
+++ b/.snapshots/TestParse-python-certifi_signed_wheel
@@ -85,7 +85,7 @@
       (string) (len=49) "Python package for providing Mozilla's CA Bundle."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=9) "2023.7.22"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) (len=20) {

--- a/.snapshots/TestParse-python-certifi_unsigned_tarball
+++ b/.snapshots/TestParse-python-certifi_unsigned_tarball
@@ -85,7 +85,7 @@
       (string) (len=49) "Python package for providing Mozilla's CA Bundle."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=9) "2023.7.22"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>

--- a/.snapshots/TestParse-python-certifi_unsigned_wheel
+++ b/.snapshots/TestParse-python-certifi_unsigned_wheel
@@ -85,7 +85,7 @@
       (string) (len=49) "Python package for providing Mozilla's CA Bundle."
     },
     (string) (len=7) "version": ([]string) (len=1) {
-      (string) (len=9) "2023.7.22"
+      (string) (len=14) "version exists"
     }
   },
   GpgSignature: ([]uint8) <nil>


### PR DESCRIPTION
As versions update, these tests will start to fail.

@jmwoliver suggested that we could store the built distributions in this repository. I see a little bit of value in using the latest versions of these libraries to ensure that we continue to pull the correct metadata as they update, although that does lead to failures occurring.