### PR TITLE
fix: update provides_extras to provides_extra to match PyPI warehouse

### DIFF
--- a/.snapshots/TestParse-configparser_signed_tarball
+++ b/.snapshots/TestParse-configparser_signed_tarball
@@ -64,7 +64,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=2) {
+    (string) (len=14) "provides_extra": ([]string) (len=2) {
       (string) (len=7) "testing",
       (string) (len=4) "docs"
     },

--- a/.snapshots/TestParse-configparser_signed_wheel
+++ b/.snapshots/TestParse-configparser_signed_wheel
@@ -64,7 +64,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=2) {
+    (string) (len=14) "provides_extra": ([]string) (len=2) {
       (string) (len=4) "docs",
       (string) (len=7) "testing"
     },

--- a/.snapshots/TestParse-configparser_unsigned_tarball
+++ b/.snapshots/TestParse-configparser_unsigned_tarball
@@ -64,7 +64,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=2) {
+    (string) (len=14) "provides_extra": ([]string) (len=2) {
       (string) (len=7) "testing",
       (string) (len=4) "docs"
     },

--- a/.snapshots/TestParse-configparser_unsigned_wheel
+++ b/.snapshots/TestParse-configparser_unsigned_wheel
@@ -64,7 +64,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=2) {
+    (string) (len=14) "provides_extra": ([]string) (len=2) {
       (string) (len=4) "docs",
       (string) (len=7) "testing"
     },

--- a/.snapshots/TestParse-coveragepy_signed_tarball
+++ b/.snapshots/TestParse-coveragepy_signed_tarball
@@ -80,7 +80,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=4) "toml"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-coveragepy_signed_wheel
+++ b/.snapshots/TestParse-coveragepy_signed_wheel
@@ -80,7 +80,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=4) "toml"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-coveragepy_unsigned_tarball
+++ b/.snapshots/TestParse-coveragepy_unsigned_tarball
@@ -80,7 +80,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=4) "toml"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-coveragepy_unsigned_wheel
+++ b/.snapshots/TestParse-coveragepy_unsigned_wheel
@@ -80,7 +80,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=4) "toml"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-importlib_metadata_signed_tarball
+++ b/.snapshots/TestParse-importlib_metadata_signed_tarball
@@ -61,7 +61,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=3) {
+    (string) (len=14) "provides_extra": ([]string) (len=3) {
       (string) (len=7) "testing",
       (string) (len=4) "docs",
       (string) (len=4) "perf"

--- a/.snapshots/TestParse-importlib_metadata_signed_wheel
+++ b/.snapshots/TestParse-importlib_metadata_signed_wheel
@@ -61,7 +61,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=3) {
+    (string) (len=14) "provides_extra": ([]string) (len=3) {
       (string) (len=4) "docs",
       (string) (len=4) "perf",
       (string) (len=7) "testing"

--- a/.snapshots/TestParse-importlib_metadata_unsigned_tarball
+++ b/.snapshots/TestParse-importlib_metadata_unsigned_tarball
@@ -61,7 +61,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=3) {
+    (string) (len=14) "provides_extra": ([]string) (len=3) {
       (string) (len=7) "testing",
       (string) (len=4) "docs",
       (string) (len=4) "perf"

--- a/.snapshots/TestParse-importlib_metadata_unsigned_wheel
+++ b/.snapshots/TestParse-importlib_metadata_unsigned_wheel
@@ -61,7 +61,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=3) {
+    (string) (len=14) "provides_extra": ([]string) (len=3) {
       (string) (len=4) "docs",
       (string) (len=4) "perf",
       (string) (len=7) "testing"

--- a/.snapshots/TestParse-pytest_signed_tarball
+++ b/.snapshots/TestParse-pytest_signed_tarball
@@ -86,7 +86,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=7) "testing"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-pytest_signed_wheel
+++ b/.snapshots/TestParse-pytest_signed_wheel
@@ -86,7 +86,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=7) "testing"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-pytest_unsigned_tarball
+++ b/.snapshots/TestParse-pytest_unsigned_tarball
@@ -86,7 +86,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=7) "testing"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/.snapshots/TestParse-pytest_unsigned_wheel
+++ b/.snapshots/TestParse-pytest_unsigned_wheel
@@ -86,7 +86,7 @@
     (string) (len=16) "protocol_version": ([]string) (len=1) {
       (string) (len=1) "1"
     },
-    (string) (len=15) "provides_extras": ([]string) (len=1) {
+    (string) (len=14) "provides_extra": ([]string) (len=1) {
       (string) (len=7) "testing"
     },
     (string) (len=9) "pyversion": ([]string) (len=1) {

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ And here is example output:
       "provides_dist": null,
       "obsoletes_dist": null,
       "project_urls": null,
-      "provides_extras": null,
+      "provides_extra": null,
       "description_content_type": "",
       "dynamic": null,
       "filename": "/path/to/appdirs/dist/appdirs-1.4.4-py2.py3-none-any.whl",

--- a/internal/distributions/distribution.go
+++ b/internal/distributions/distribution.go
@@ -111,7 +111,7 @@ var HeaderAttrs1_2 = append(HeaderAttrs1_1, []HeaderAttr{ // PEP 345
 var HeaderAttrs2_0 = HeaderAttrs1_2 //XXX PEP 426?
 
 var HeaderAttrs2_1 = append(HeaderAttrs1_2, []HeaderAttr{ // PEP 566
-	{"Provides-Extra", "provides_extras", true},
+	{"Provides-Extra", "provides_extra", true},
 	{"Description-Content-Type", "description_content_type", false},
 }...)
 
@@ -171,7 +171,7 @@ type BaseDistribution struct {
 	ObsoletesDist    []string `json:"obsoletes_dist"`
 	ProjectURLs      []string `json:"project_urls"`
 	// version 2.1
-	ProvidesExtras         []string `json:"provides_extras"`
+	ProvidesExtras         []string `json:"provides_extra"`
 	DescriptionContentType string   `json:"description_content_type"`
 	// version 2.2
 	Dynamic []string `json:"dynamic"`


### PR DESCRIPTION
It looks like PyPI warehouse changed provides_extras to provides_extra, breaking our tests. Here's the related Twine update: https://github.com/pypa/twine/commit/637a6c0929dac95b6616f877bd97da9c98e01416